### PR TITLE
Add support for client order ids

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -20,6 +20,7 @@ import {
 import { SelfTradeBehavior } from "./state";
 import { Market } from "./market";
 import { TOKEN_PROGRAM_ID } from "@solana/spl-token";
+import crypto from "crypto";
 
 /**
  * Constants
@@ -125,7 +126,7 @@ export const placeOrder = async (
   selfTradeBehaviour: SelfTradeBehavior,
   ownerTokenAccount: PublicKey,
   owner: PublicKey,
-  clientOrderId: BN,
+  clientOrderId?: BN,
   discountTokenAccount?: PublicKey
 ) => {
   const [userAccount] = await PublicKey.findProgramAddress(
@@ -137,6 +138,10 @@ export const placeOrder = async (
   // if (!discountTokenAccount) {
   //   discountTokenAccount = await findAssociatedTokenAddress(owner, SRM_MINT);
   // }
+
+  if (!clientOrderId) {
+    clientOrderId = new BN(crypto.randomBytes(16));
+  }
 
   const instruction = new newOrderInstruction({
     side: side as number,

--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -97,9 +97,6 @@ export const createMarket = async (
     minBaseOrderSize: new BN(minBaseOrderSize),
     tickSize: tickSize,
     crankerReward: new BN(crankerReward),
-    feeTierThresholds,
-    feeTierTakerBpsRates,
-    feeTierMakerBpsRebates,
   }).getInstruction(
     DEX_ID,
     marketAccount.publicKey,
@@ -128,6 +125,7 @@ export const placeOrder = async (
   selfTradeBehaviour: SelfTradeBehavior,
   ownerTokenAccount: PublicKey,
   owner: PublicKey,
+  clientOrderId: BN,
   discountTokenAccount?: PublicKey
 ) => {
   const [userAccount] = await PublicKey.findProgramAddress(
@@ -147,7 +145,9 @@ export const placeOrder = async (
     maxQuoteQty: new BN(Math.ceil(size * limitPrice)),
     orderType: type,
     selfTradeBehavior: selfTradeBehaviour,
-    matchLimit: new BN(Number.MAX_SAFE_INTEGER), // TODO Change
+    matchLimit: new BN(Number.MAX_SAFE_INTEGER),
+    clientOrderId,
+    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1, // TODO Change
   }).getInstruction(
     DEX_ID,
     TOKEN_PROGRAM_ID,

--- a/js/src/market.ts
+++ b/js/src/market.ts
@@ -378,6 +378,7 @@ export class Market {
     selfTradeBehavior: SelfTradeBehavior,
     ownerTokenAccount: PublicKey,
     owner: Keypair,
+    clientOrderId: BN,
     discountTokenAccount?: PublicKey
   ) {
     const inst = await this.makePlaceOrderTransaction(
@@ -388,6 +389,7 @@ export class Market {
       selfTradeBehavior,
       ownerTokenAccount,
       owner.publicKey,
+      clientOrderId,
       discountTokenAccount
     );
     const tx = new Transaction().add(inst);
@@ -414,6 +416,7 @@ export class Market {
     selfTradeBehavior: SelfTradeBehavior,
     ownerTokenAccount: PublicKey,
     owner: PublicKey,
+    clientOrderId: BN,
     discountTokenAccount?: PublicKey
   ) {
     return await placeOrder(
@@ -425,6 +428,7 @@ export class Market {
       selfTradeBehavior,
       ownerTokenAccount,
       owner,
+      clientOrderId,
       discountTokenAccount
     );
   }
@@ -516,7 +520,7 @@ export class Market {
       this.address,
       owner.publicKey
     );
-    const orderId = openOrders.orders[orderIndex];
+    const orderId = openOrders.orders[orderIndex].id;
     if (!orderId) {
       throw new Error(`Invalid order index ${orderIndex}`);
     }
@@ -547,7 +551,7 @@ export class Market {
       owner.publicKey
     );
     const orderIndex = openOrders.orders
-      .map((o) => o.eq(orderId))
+      .map((o) => o.id.eq(orderId))
       .indexOf(true);
     if (orderIndex === -1) {
       throw new Error("Invalid order id");
@@ -661,7 +665,9 @@ export class Market {
   filterForOpenOrdersFromSlab(slab: Slab, openOrders: OpenOrders, side: Side) {
     return [...slab]
       .filter((o) =>
-        openOrders?.address.equals(new PublicKey(slab.getCallBackInfo(o.callBackInfoPt).slice(0, 32)))
+        openOrders?.address.equals(
+          new PublicKey(slab.getCallBackInfo(o.callBackInfoPt).slice(0, 32))
+        )
       )
       .map((o) => {
         return {
@@ -669,7 +675,9 @@ export class Market {
           price: getPriceFromKey(o.key).toNumber(),
           feeTier: slab.getCallBackInfo(o.callBackInfoPt).slice(32)[0],
           size: o.baseQuantity.toNumber(),
-          openOrdersAddress: new PublicKey(slab.getCallBackInfo(o.callBackInfoPt).slice(0, 32)),
+          openOrdersAddress: new PublicKey(
+            slab.getCallBackInfo(o.callBackInfoPt).slice(0, 32)
+          ),
           side: side,
         };
       });

--- a/js/src/openOrders.ts
+++ b/js/src/openOrders.ts
@@ -1,7 +1,7 @@
 import { Connection, PublicKey } from "@solana/web3.js";
 import BN from "bn.js";
 import { DEX_ID } from "./ids";
-import { UserAccount } from "./state";
+import { Order, UserAccount } from "./state";
 import { closeAccount, initializeAccount } from "./bindings";
 
 /**
@@ -53,7 +53,7 @@ export class OpenOrders {
    * List of orders of the open order account
    * @private
    */
-  private _orders: BN[];
+  private _orders: Order[];
 
   /**
    * Amount of accumulated rebates
@@ -69,7 +69,7 @@ export class OpenOrders {
     baseTokenTotal: BN,
     quoteTokenFree: BN,
     quoteTokenTotal: BN,
-    orders: BN[],
+    orders: Order[],
     accumulatedRebates: BN
   ) {
     this._address = address;
@@ -134,7 +134,7 @@ export class OpenOrders {
   /**
    * Returns the list of orders of the open orders account
    */
-  get orders(): BN[] {
+  get orders(): Order[] {
     return this._orders;
   }
 

--- a/js/src/raw_instructions.ts
+++ b/js/src/raw_instructions.ts
@@ -80,6 +80,7 @@ export class newOrderInstruction {
   maxBaseQty: BN;
   maxQuoteQty: BN;
   matchLimit: BN;
+  clientOrderId: BN;
   side: number;
   orderType: number;
   selfTradeBehavior: number;
@@ -96,6 +97,7 @@ export class newOrderInstruction {
           ["maxBaseQty", "u64"],
           ["maxQuoteQty", "u64"],
           ["matchLimit", "u64"],
+          ["clientOrderId", "u128"],
           ["side", "u8"],
           ["orderType", "u8"],
           ["selfTradeBehavior", "u8"],
@@ -110,6 +112,7 @@ export class newOrderInstruction {
     maxBaseQty: BN;
     maxQuoteQty: BN;
     matchLimit: BN;
+    clientOrderId: BN;
     side: number;
     orderType: number;
     selfTradeBehavior: number;
@@ -120,11 +123,12 @@ export class newOrderInstruction {
     this.maxBaseQty = obj.maxBaseQty;
     this.maxQuoteQty = obj.maxQuoteQty;
     this.matchLimit = obj.matchLimit;
+    this.clientOrderId = obj.clientOrderId;
     this.side = obj.side;
     this.orderType = obj.orderType;
     this.selfTradeBehavior = obj.selfTradeBehavior;
     this.hasDiscountTokenAccount = obj.hasDiscountTokenAccount;
-    this.padding = new Uint8Array(4).fill(0);
+    this.padding = 0;
   }
   serialize(): Uint8Array {
     return serialize(newOrderInstruction.schema, this);

--- a/js/src/state.ts
+++ b/js/src/state.ts
@@ -103,6 +103,16 @@ export class MarketState {
   }
 }
 
+export class Order {
+  id: BN;
+  clientId: BN;
+
+  constructor(obj: { id: BN; clientId: BN }) {
+    this.clientId = obj.clientId;
+    this.id = obj.id;
+  }
+}
+
 export class UserAccount {
   tag: AccountTag;
   market: PublicKey;
@@ -116,8 +126,9 @@ export class UserAccount {
   accumulatedMakerBaseVolume: BN;
   accumulatedTakerQuoteVolume: BN;
   accumulatedTakerBaseVolume: BN;
-  orders: BN[];
+  orders: Order[];
 
+  // @ts-ignore
   static schema: Schema = new Map([
     [
       UserAccount,
@@ -137,7 +148,17 @@ export class UserAccount {
           ["accumulatedTakerQuoteVolume", "u64"],
           ["accumulatedTakerBaseVolume", "u64"],
           ["_padding", "u32"],
-          ["orders", ["u128"]],
+          ["orders", [Order]],
+        ],
+      },
+    ],
+    [
+      Order,
+      {
+        kind: "struct",
+        fields: [
+          ["id", "u128"],
+          ["clientId", "u128"],
         ],
       },
     ],
@@ -151,7 +172,7 @@ export class UserAccount {
     baseTokenLocked: BN;
     quoteTokenFree: BN;
     quoteTokenLocked: BN;
-    orders: BN[];
+    orders: Order[];
     accumulatedRebates: BN;
     accumulatedMakerQuoteVolume: BN;
     accumulatedMakerBaseVolume: BN;

--- a/js/src/state.ts
+++ b/js/src/state.ts
@@ -205,4 +205,12 @@ export class UserAccount {
       accountInfo.data
     ) as UserAccount;
   }
+
+  getOrderId(clientOrderId: BN): BN | undefined {
+    return this.orders.find((o) => o.clientId === clientOrderId)?.id;
+  }
+
+  getClientOrderId(orderId: BN): BN | undefined {
+    return this.orders.find((o) => o.id === orderId)?.clientId;
+  }
 }

--- a/js/src/test.ts
+++ b/js/src/test.ts
@@ -111,7 +111,8 @@ const test = async () => {
     OrderType.Limit,
     SelfTradeBehavior.CancelProvide,
     await findAssociatedTokenAddress(wallet.publicKey, market.baseMintAddress),
-    wallet.publicKey
+    wallet.publicKey,
+    new BN(0)
   );
   const tx = await signAndSendTransactionInstructions(
     connection,

--- a/program/src/instruction.rs
+++ b/program/src/instruction.rs
@@ -1,0 +1,197 @@
+#![allow(clippy::too_many_arguments)]
+use crate::processor::close_account;
+pub use crate::processor::{
+    cancel_order, close_market, consume_events, create_market, initialize_account, new_order,
+    settle, sweep_fees,
+};
+use bonfida_utils::InstructionsAccount;
+use num_derive::{FromPrimitive, ToPrimitive};
+use solana_program::{instruction::Instruction, pubkey::Pubkey};
+#[derive(Clone, Copy, FromPrimitive, ToPrimitive)]
+///   Describes all possible instructions and their required accounts
+pub enum DexInstruction {
+    /// Creates a new DEX market
+    ///
+    /// | Index | Writable | Signer | Description                 |
+    /// | ------------------------------------------------------- |
+    /// | 0     | ✅        | ❌      | The market account          |
+    /// | 1     | ✅        | ❌      | The orderbook account       |
+    /// | 2     | ❌        | ❌      | The base vault account      |
+    /// | 3     | ❌        | ❌      | The quote vault account     |
+    /// | 4     | ❌        | ❌      | The market admin account    |
+    /// | 5     | ✅        | ❌      | The AOB event queue account |
+    /// | 6     | ✅        | ❌      | The AOB asks account        |
+    /// | 7     | ✅        | ❌      | The AOB bids account        |
+    CreateMarket,
+    /// Execute a new order instruction. Supported types include Limit, IOC, FOK, or Post only.
+    ///
+    /// | Index | Writable | Signer | Description                                                                        |
+    /// | -------------------------------------------------------------------------------------------------------------- |
+    /// | 0     | ❌        | ❌      | The SPL token program                                                              |
+    /// | 1     | ❌        | ❌      | The system program                                                                 |
+    /// | 2     | ✅        | ❌      | The DEX market                                                                     |
+    /// | 3     | ✅        | ❌      | The orderbook                                                                      |
+    /// | 4     | ✅        | ❌      | The AOB event queue                                                                |
+    /// | 5     | ✅        | ❌      | The AOB bids shared memory                                                         |
+    /// | 6     | ✅        | ❌      | The AOB asks shared memory                                                         |
+    /// | 7     | ✅        | ❌      | The base token vault                                                               |
+    /// | 8     | ✅        | ❌      | The quote token vault                                                              |
+    /// | 9     | ✅        | ❌      | The DEX user account                                                               |
+    /// | 10    | ✅        | ❌      | The user source token account                                                      |
+    /// | 11    | ✅        | ✅      | The user wallet                                                                    |
+    /// | 12    | ❌        | ❌      | The optional SRM or MSRM discount token account (must be owned by the user wallet) |
+    /// | 13    | ✅        | ❌      | The optional referrer's token account which will receive a 20% cut of the fees     |
+    NewOrder,
+    /// Cancel an existing order and remove it from the orderbook.
+    ///
+    /// | Index | Writable | Signer | Description                |
+    /// | ------------------------------------------------------ |
+    /// | 0     | ❌        | ❌      | The DEX market             |
+    /// | 1     | ✅        | ❌      | The orderbook              |
+    /// | 2     | ✅        | ❌      | The AOB event queue        |
+    /// | 3     | ✅        | ❌      | The AOB bids shared memory |
+    /// | 4     | ✅        | ❌      | The AOB asks shared memory |
+    /// | 5     | ✅        | ❌      | The DEX user account       |
+    /// | 6     | ❌        | ✅      | The user wallet            |
+    CancelOrder,
+    /// Crank the processing of DEX events.
+    ///
+    /// | Index    | Writable | Signer | Description                |
+    /// | --------------------------------------------------------- |
+    /// | 0        | ✅        | ❌      | The DEX market             |
+    /// | 1        | ✅        | ❌      | The orderbook              |
+    /// | 2        | ✅        | ❌      | The AOB event queue        |
+    /// | 3        | ✅        | ❌      | The reward target          |
+    /// | 4..4 + N | ✅        | ❌      | The relevant user accounts |
+    ConsumeEvents,
+    /// Extract available base and quote token assets from a user account
+    ///
+    /// | Index | Writable | Signer | Description                         |
+    /// | --------------------------------------------------------------- |
+    /// | 0     | ❌        | ❌      | The spl token program               |
+    /// | 1     | ❌        | ❌      | The DEX market                      |
+    /// | 2     | ✅        | ❌      | The base token vault                |
+    /// | 3     | ✅        | ❌      | The quote token vault               |
+    /// | 4     | ❌        | ❌      | The DEX market signer account       |
+    /// | 5     | ✅        | ❌      | The DEX user account                |
+    /// | 6     | ❌        | ✅      | The DEX user account owner wallet   |
+    /// | 7     | ✅        | ❌      | The destination base token account  |
+    /// | 8     | ✅        | ❌      | The destination quote token account |
+    Settle,
+    /// Initialize a new user account
+    ///
+    /// | Index | Writable | Signer | Description                    |
+    /// | ---------------------------------------------------------- |
+    /// | 0     | ❌        | ❌      | The system program             |
+    /// | 1     | ✅        | ❌      | The user account to initialize |
+    /// | 2     | ❌        | ✅      | The owner of the user account  |
+    /// | 3     | ✅        | ✅      | The fee payer                  |
+    InitializeAccount,
+    /// Extract accumulated fees from the market. This is an admin instruction
+    ///
+    /// | Index | Writable | Signer | Description                   |
+    /// | --------------------------------------------------------- |
+    /// | 0     | ✅        | ❌      | The DEX market                |
+    /// | 1     | ❌        | ❌      | The DEX market signer         |
+    /// | 2     | ❌        | ✅      | The market admin              |
+    /// | 3     | ✅        | ❌      | The market quote token vault  |
+    /// | 4     | ✅        | ❌      | The destination token account |
+    /// | 5     | ❌        | ❌      | The spl token program         |
+    SweepFees,
+    /// Close an inactive and empty user account
+    ///
+    /// | Index | Writable | Signer | Description                            |
+    /// | ------------------------------------------------------------------ |
+    /// | 0     | ✅        | ❌      | The user account to close              |
+    /// | 1     | ❌        | ✅      | The owner of the user account to close |
+    /// | 2     | ✅        | ❌      | The target lamports account            |
+    CloseAccount,
+    /// Close an existing market
+    ///
+    /// | Index | Writable | Signer | Description                    |
+    /// | ---------------------------------------------------------- |
+    /// | 0     | ✅        | ❌      | The market account             |
+    /// | 1     | ✅        | ❌      | The market base vault account  |
+    /// | 2     | ✅        | ❌      | The market quote vault account |
+    /// | 3     | ✅        | ❌      | The AOB orderbook account      |
+    /// | 4     | ✅        | ❌      | The AOB event queue account    |
+    /// | 5     | ✅        | ❌      | The AOB bids account           |
+    /// | 6     | ✅        | ❌      | The AOB asks account           |
+    /// | 7     | ❌        | ✅      | The makret admin account       |
+    /// | 8     | ✅        | ❌      | The target lamports account    |
+    CloseMarket,
+}
+///   Create a new DEX market
+///
+///   The asset agnostic orderbook must be properly initialized beforehand.
+pub fn create_market(
+    program_id: Pubkey,
+    accounts: create_market::Accounts<Pubkey>,
+    params: create_market::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::CreateMarket as u8, params)
+}
+///  \\nExecute a new order on the orderbook.\\n\\nDepending on the provided parameters, the program will attempt to match the order with existing entries\\nin the orderbook, and then optionally post the remaining order.\\n
+pub fn new_order(
+    program_id: Pubkey,
+    accounts: new_order::Accounts<Pubkey>,
+    params: new_order::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::NewOrder as u8, params)
+}
+///   Cancel an existing order and remove it from the orderbook.
+pub fn cancel_order(
+    program_id: Pubkey,
+    accounts: cancel_order::Accounts<Pubkey>,
+    params: cancel_order::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::CancelOrder as u8, params)
+}
+///   Crank the processing of DEX events.
+pub fn consume_events(
+    program_id: Pubkey,
+    accounts: consume_events::Accounts<Pubkey>,
+    params: consume_events::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::ConsumeEvents as u8, params)
+}
+///   Extract available base and quote token assets from a user account
+pub fn settle(
+    program_id: Pubkey,
+    accounts: settle::Accounts<Pubkey>,
+    params: settle::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::Settle as u8, params)
+}
+///   Initialize a new user account
+pub fn initialize_account(
+    program_id: Pubkey,
+    accounts: initialize_account::Accounts<Pubkey>,
+    params: initialize_account::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::InitializeAccount as u8, params)
+}
+///   Extract accumulated fees from the market. This is an admin instruction
+pub fn sweep_fees(
+    program_id: Pubkey,
+    accounts: sweep_fees::Accounts<Pubkey>,
+    params: sweep_fees::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::SweepFees as u8, params)
+}
+///   Close an inactive and fully settled account
+pub fn close_account(
+    program_id: Pubkey,
+    accounts: close_account::Accounts<Pubkey>,
+    params: close_account::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::CloseAccount as u8, params)
+}
+///   Close an existing market
+pub fn close_market(
+    program_id: Pubkey,
+    accounts: close_market::Accounts<Pubkey>,
+    params: close_market::Params,
+) -> Instruction {
+    accounts.get_instruction_cast(program_id, DexInstruction::CloseMarket as u8, params)
+}

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -126,7 +126,7 @@ pub(crate) fn process(
 
     check_accounts(&market_state, &accounts).unwrap();
 
-    let order_id_from_index = user_account.read_order(*order_index as usize)?;
+    let order_id_from_index = user_account.read_order(*order_index as usize)?.id;
 
     if order_id != &order_id_from_index {
         msg!("Order id does not match with the order at the given index!");

--- a/program/src/processor/initialize_account.rs
+++ b/program/src/processor/initialize_account.rs
@@ -106,7 +106,7 @@ pub(crate) fn process(
         msg!("The minimum number of orders an account should be able to hold is 1");
         return Err(ProgramError::InvalidArgument);
     }
-    let space = (USER_ACCOUNT_HEADER_LEN as u64) + max_orders * (u128::LEN as u64);
+    let space = (USER_ACCOUNT_HEADER_LEN as u64) + max_orders * (Order::LEN as u64);
 
     let lamports = Rent::get()?.minimum_balance(space as usize);
 

--- a/program/tests/common/performance_test_utils.rs
+++ b/program/tests/common/performance_test_utils.rs
@@ -440,6 +440,7 @@ pub async fn aob_dex_new_order(
             order_type: new_order::OrderType::Limit as u8,
             self_trade_behavior: agnostic_orderbook::state::SelfTradeBehavior::DecrementTake as u8,
             match_limit: 10,
+            client_order_id: 0,
             has_discount_token_account: false as u8,
             _padding: 0,
         },

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -223,6 +223,7 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            client_order_id: 0,
             side: agnostic_orderbook::state::Side::Ask as u8,
             limit_price: 1 << 32,
             max_base_qty: 100_000,
@@ -301,6 +302,7 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            client_order_id: 0,
             side: agnostic_orderbook::state::Side::Ask as u8,
             limit_price: 1000 << 32,
             max_base_qty: 110000,
@@ -340,6 +342,7 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            client_order_id: 0,
             side: agnostic_orderbook::state::Side::Bid as u8,
             limit_price: 1000 << 32,
             max_base_qty: 100000,


### PR DESCRIPTION
Proposal for closing Issue #36.

This PR increases the size of an order in the user's account in order to store a `client_order_id` in addition to the underlying AOB-generated `order_id`. This `client_order_id` is provided in `new_order`, and cannot be changed afterwards. All raw interactions with the program will still use the normal `order_id`, but bindings can be written to map `client_order_id`s to their underlying `order_id`. Since the program itself never bothers itself with `client_order_ids` beyond simple storage, clients enabling its use will have to ensure that each order has a unique `client_order_id` to avoid collisions during the off-chain mapping process.