### PR TITLE
Add aarch64-test feature and fix compilation for the aarch64 target

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [features]
 no-entrypoint = []
 no-admin = []
+aarch64-test = []
 
 [dependencies]
 num-derive = "0.3.3"

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -35,8 +35,11 @@ use super::REFERRAL_MASK;
 The required arguments for a new_order instruction.
 */
 pub struct Params {
+    #[cfg(all(not(target_arch = "aarch64"), not(feature = "aarch64-test")))]
     /// The client order id number that will be stored in the user account
     pub client_order_id: u128,
+    #[cfg(any(target_arch = "aarch64", feature = "aarch64-test"))]
+    pub client_order_id: [u64; 2],
     /// The order's limit price (as a FP32)
     pub limit_price: u64,
     /// The max quantity of base token to match and post
@@ -227,6 +230,8 @@ pub(crate) fn process(
         client_order_id,
         _padding: _,
     } = try_from_bytes(instruction_data).map_err(|_| ProgramError::InvalidInstructionData)?;
+    #[cfg(any(target_arch = "aarch64", feature = "aarch64-test"))]
+    let client_order_id: &u128 = bytemuck::cast_ref(client_order_id);
     let accounts = Accounts::parse(program_id, accounts, *has_discount_token_account != 0)?;
 
     let market_state = DexState::get(accounts.market)?;

--- a/program/tests/common/performance_test_utils.rs
+++ b/program/tests/common/performance_test_utils.rs
@@ -442,7 +442,10 @@ pub async fn aob_dex_new_order(
             order_type: new_order::OrderType::Limit as u8,
             self_trade_behavior: agnostic_orderbook::state::SelfTradeBehavior::DecrementTake as u8,
             match_limit: 10,
+            #[cfg(not(any(feature = "aarch64-test", target_arch = "aarch64")))]
             client_order_id: 0,
+            #[cfg(any(feature = "aarch64-test", target_arch = "aarch64"))]
+            client_order_id: bytemuck::cast(0u128),
             has_discount_token_account: false as u8,
             _padding: 0,
         },

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -311,7 +311,10 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            #[cfg(not(any(feature = "aarch64-test", target_arch = "aarch64")))]
             client_order_id: 0,
+            #[cfg(any(feature = "aarch64-test", target_arch = "aarch64"))]
+            client_order_id: bytemuck::cast(0u128),
             side: agnostic_orderbook::state::Side::Ask as u8,
             limit_price: 1 << 32,
             max_base_qty: 100_000,
@@ -392,7 +395,10 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            #[cfg(not(any(feature = "aarch64-test", target_arch = "aarch64")))]
             client_order_id: 0,
+            #[cfg(any(feature = "aarch64-test", target_arch = "aarch64"))]
+            client_order_id: bytemuck::cast(0u128),
             side: agnostic_orderbook::state::Side::Ask as u8,
             limit_price: 1000 << 32,
             max_base_qty: 110000,
@@ -432,7 +438,10 @@ async fn test_dex() {
             fee_referral_account: None,
         },
         new_order::Params {
+            #[cfg(not(any(feature = "aarch64-test", target_arch = "aarch64")))]
             client_order_id: 0,
+            #[cfg(any(feature = "aarch64-test", target_arch = "aarch64"))]
+            client_order_id: bytemuck::cast(0u128),
             side: agnostic_orderbook::state::Side::Bid as u8,
             limit_price: 1000 << 32,
             max_base_qty: 100000,


### PR DESCRIPTION
This PR aims to fix compilation for aarch64 targets (including the Apple M1 architecture).