### PR TITLE
Fix limit price calculation in placeOrder + expose bindings

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -142,14 +142,15 @@ export const placeOrder = async (
     clientOrderId = new BN(crypto.randomBytes(16));
   }
 
-  const mul = Math.pow(10, market.quoteDecimals - market.baseDecimals);
-  const price = new BN(mul).mul(new BN(limitPrice)).mul(new BN(2 ** 32));
+  const formattedLimitPrice =
+    Math.pow(10, market.quoteDecimals - market.baseDecimals) * limitPrice;
+  const price = new BN(formattedLimitPrice).mul(new BN(Math.pow(2, 32)));
 
   const instruction = new newOrderInstruction({
     side: side as number,
     limitPrice: price,
     maxBaseQty: new BN(size),
-    maxQuoteQty: new BN(Math.ceil(size * limitPrice)),
+    maxQuoteQty: new BN(Math.ceil(size * formattedLimitPrice)),
     orderType: type,
     selfTradeBehavior: selfTradeBehaviour,
     matchLimit: new BN(Number.MAX_SAFE_INTEGER),

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -3,3 +3,4 @@ export * from "./openOrders";
 export * from "./orderbook";
 export * from "./ids";
 export * from "./types";
+export * from "./bindings";


### PR DESCRIPTION
1. Expose `bindings`
2. Currently, `limitPrice` is expected to be the UI amount, but BN doesn't support floating point (so `BN(1.5) == BN(1)`). Logic should first multiply the raw number by decimals, then convert to BN