### PR TITLE
Misc fixes, utilities, configs

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: "none",
+  tabWidth: 2,
+  semi: true,
+  singleQuote: false,
+};

--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -3,7 +3,7 @@ import {
   PublicKey,
   Connection,
   SystemProgram,
-  TransactionInstruction,
+  TransactionInstruction
 } from "@solana/web3.js";
 import { DEX_ID, SRM_MINT } from "./ids";
 import {
@@ -16,7 +16,7 @@ import {
   closeAccountInstruction,
   swapInstruction,
   closeMarketInstruction,
-  sweepFeesInstruction,
+  sweepFeesInstruction
 } from "./raw_instructions";
 import { OrderType, PrimedTransaction, Side } from "./types";
 import * as aaob from "@bonfida/aaob";
@@ -26,7 +26,7 @@ import { Market } from "./market";
 import {
   TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress,
+  getAssociatedTokenAddress
 } from "@solana/spl-token";
 import crypto from "crypto";
 import { getMetadataKeyFromMint } from "./metadata";
@@ -71,6 +71,7 @@ export const createMarket = async (
   // Market Account
   const marketAccount = new Keypair();
   console.log(`Market address ${marketAccount.publicKey.toBase58()}`);
+  console.log(`Metadata address ${metadataAccount.toBase58()}`);
   const balance = await connection.getMinimumBalanceForRentExemption(
     MARKET_STATE_SPACE
   );
@@ -89,7 +90,7 @@ export const createMarket = async (
     lamports: balance,
     newAccountPubkey: marketAccount.publicKey,
     programId,
-    space: MARKET_STATE_SPACE,
+    space: MARKET_STATE_SPACE
   });
 
   // Market signer
@@ -135,7 +136,7 @@ export const createMarket = async (
     minBaseOrderSize: new BN(minBaseOrderSize),
     tickSize: tickSize,
     baseCurrencyMultiplier,
-    quoteCurrencyMultiplier,
+    quoteCurrencyMultiplier
   }).getInstruction(
     programId,
     marketAccount.publicKey,
@@ -152,7 +153,7 @@ export const createMarket = async (
   return [
     [[marketAccount], [createMarketAccount]],
     [aaobSigners, aaobInstructions],
-    [[], [createBaseVault, createQuoteVault, createMarket]],
+    [[], [createBaseVault, createQuoteVault, createMarket]]
   ];
 };
 
@@ -210,7 +211,7 @@ export const placeOrder = async (
     selfTradeBehavior: selfTradeBehaviour,
     matchLimit: new BN(Number.MAX_SAFE_INTEGER),
     clientOrderId,
-    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1, // TODO Change
+    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1 // TODO Change
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,
@@ -255,7 +256,7 @@ export const cancelOrder = async (
   const instruction = new cancelOrderInstruction({
     orderId: clientOrderId ? clientOrderId : orderId,
     orderIndex: orderIndex ? orderIndex : new BN(0),
-    isClientId: clientOrderId ? 1 : 0,
+    isClientId: clientOrderId ? 1 : 0
   }).getInstruction(
     market.programId,
     market.address,
@@ -292,7 +293,7 @@ export const initializeAccount = async (
 
   const instruction = new initializeAccountInstruction({
     market: market.toBuffer(),
-    maxOrders: new BN(maxOrders),
+    maxOrders: new BN(maxOrders)
   }).getInstruction(
     programId,
     SystemProgram.programId,
@@ -362,7 +363,7 @@ export const consumeEvents = async (
 ) => {
   const instruction = new consumeEventsInstruction({
     maxIterations,
-    noOpErr,
+    noOpErr
   }).getInstruction(
     market.programId,
     market.address,
@@ -428,7 +429,7 @@ export const swap = async (
     quoteQty:
       side === Side.Bid ? new BN(inputQuantity) : new BN(minOutputQuantity),
     matchLimit: new BN(Number.MAX_SAFE_INTEGER), // TODO Change
-    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined),
+    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined)
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,

--- a/js/src/openOrders.ts
+++ b/js/src/openOrders.ts
@@ -3,7 +3,6 @@ import BN from "bn.js";
 import { DEX_ID } from "./ids";
 import { MarketState, Order, UserAccount } from "./state";
 import { closeAccount, initializeAccount } from "./bindings";
-import { BuiltInParserName } from "prettier";
 
 /**
  * Open Orders class
@@ -157,9 +156,13 @@ export class OpenOrders {
     connection: Connection,
     market: PublicKey,
     owner: PublicKey,
-    marketState: MarketState,
+    marketState?: MarketState,
     programId = DEX_ID
   ) {
+    if (!marketState) {
+      marketState = await MarketState.retrieve(connection, market);
+    }
+
     const [address] = await PublicKey.findProgramAddress(
       [market.toBuffer(), owner.toBuffer()],
       programId

--- a/js/src/orderbook.ts
+++ b/js/src/orderbook.ts
@@ -9,7 +9,7 @@ import BN from "bn.js";
 /**
  * Orderbook class
  */
-export class Orderbook implements GetL2 {
+export class Orderbook {
   /** Market of the orderbook
    * @private
    */
@@ -85,7 +85,16 @@ export class Orderbook implements GetL2 {
    * @param uiAmount Optional, whether to return the amounts in uiAmount
    * @returns Returns an L2 orderbook
    */
-  getL2(depth: number, asks: boolean, uiAmount = false) {
+  getL2<T extends boolean>(
+    depth: number,
+    asks: boolean,
+    uiAmount: T
+  ): (T extends true ? UiPrice : aaob.Price)[];
+  getL2(
+    depth: number,
+    asks: boolean,
+    uiAmount = false
+  ): (UiPrice | aaob.Price)[] {
     const convert = (p: aaob.Price) => {
       return {
         price: computeUiPrice(this._market, p.price),
@@ -96,26 +105,17 @@ export class Orderbook implements GetL2 {
       };
     };
     if (uiAmount) {
-      return (
-        asks
-          ? this._slabAsks.getL2DepthJS(depth, asks).map(convert)
-          : this._slabBids.getL2DepthJS(depth, asks).map(convert)
-      ) as any;
+      return asks
+        ? this._slabAsks.getL2DepthJS(depth, asks).map(convert)
+        : this._slabBids.getL2DepthJS(depth, asks).map(convert);
     }
-    return (
-      asks
-        ? this._slabAsks.getL2DepthJS(depth, asks)
-        : this._slabBids.getL2DepthJS(depth, asks)
-    ) as any;
+    return asks
+      ? this._slabAsks.getL2DepthJS(depth, asks)
+      : this._slabBids.getL2DepthJS(depth, asks);
   }
 }
 
-export interface GetL2 {
-  getL2: {
-    (depth: number, asks: boolean, uiAmount: false): aaob.Price[];
-    (depth: number, asks: boolean, uiAmount: true): {
-      price: number;
-      size: number;
-    };
-  };
+export interface UiPrice {
+  price: number;
+  size: number;
 }

--- a/js/src/orderbook.ts
+++ b/js/src/orderbook.ts
@@ -1,7 +1,7 @@
 import { Slab } from "@bonfida/aaob";
 import { PublicKey, Connection } from "@solana/web3.js";
 import { Market } from "./market";
-import { throwIfNull } from "./utils";
+import { computeUiPrice, divideBnToNumber, throwIfNull } from "./utils";
 import * as aaob from "@bonfida/aaob";
 import { CALLBACK_INFO_LEN } from "./state";
 import BN from "bn.js";
@@ -9,7 +9,7 @@ import BN from "bn.js";
 /**
  * Orderbook class
  */
-export class Orderbook {
+export class Orderbook implements GetL2 {
   /** Market of the orderbook
    * @private
    */
@@ -85,20 +85,37 @@ export class Orderbook {
    * @param uiAmount Optional, whether to return the amounts in uiAmount
    * @returns Returns an L2 orderbook
    */
-  getL2(depth: number, asks: boolean, uiAmount?: boolean) {
+  getL2(depth: number, asks: boolean, uiAmount = false) {
     const convert = (p: aaob.Price) => {
       return {
-        price: p.price,
-        size: p.size.divn(Math.pow(10, this.market.baseDecimals)),
+        price: computeUiPrice(this._market, p.price),
+        size: divideBnToNumber(
+          p.size,
+          new BN(10).pow(new BN(this.market.baseDecimals))
+        )
       };
     };
     if (uiAmount) {
-      return asks
-        ? this._slabAsks.getL2DepthJS(depth, asks).map(convert)
-        : this._slabBids.getL2DepthJS(depth, asks).map(convert);
+      return (
+        asks
+          ? this._slabAsks.getL2DepthJS(depth, asks).map(convert)
+          : this._slabBids.getL2DepthJS(depth, asks).map(convert)
+      ) as any;
     }
-    return asks
-      ? this._slabAsks.getL2DepthJS(depth, asks)
-      : this._slabBids.getL2DepthJS(depth, asks);
+    return (
+      asks
+        ? this._slabAsks.getL2DepthJS(depth, asks)
+        : this._slabBids.getL2DepthJS(depth, asks)
+    ) as any;
   }
+}
+
+export interface GetL2 {
+  getL2: {
+    (depth: number, asks: boolean, uiAmount: false): aaob.Price[];
+    (depth: number, asks: boolean, uiAmount: true): {
+      price: number;
+      size: number;
+    };
+  };
 }

--- a/program/Anchor.toml
+++ b/program/Anchor.toml
@@ -1,0 +1,10 @@
+anchor_version = "0.18.2"
+
+[workspace]
+members = [
+    ".",
+]
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"

--- a/program/Cargo.lock
+++ b/program/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 [[package]]
 name = "agnostic-orderbook"
 version = "1.0.0"
-source = "git+https://github.com/Bonfida/agnostic-orderbook.git#375825425d8f47c7ed61fbbda41e54e5b05f215c"
+source = "git+https://github.com/Bonfida/agnostic-orderbook.git#57fe4d656f5795776dc52143573352e8e469e623"
 dependencies = [
  "bonfida-utils",
  "borsh",


### PR DESCRIPTION
* Added `Anchor.toml` to allow using anchor cli
* Added `.prettierrc.js`. Tried to match it to the current format as closely as possible (some files had trailing commas and some didn't so chose `none` for now).
* Added `computeUiPrice` utility function
* Changed `tickSize` and `minOrderSize` to be uiAmounts for backward compatibility with v3. Added `tickSizeBN` and `minOrderSizeBN` for BN amounts.
* Made `marketState` optional on `OpenOrders.load` for backwards compatibility.
* Fixed `convert` function in `Orderbook.getL2` and added typing.