### PR TITLE
Confine multiplier abstraction to AOB

### DIFF
--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -3,7 +3,7 @@ import {
   PublicKey,
   Connection,
   SystemProgram,
-  TransactionInstruction
+  TransactionInstruction,
 } from "@solana/web3.js";
 import { DEX_ID, SRM_MINT } from "./ids";
 import {
@@ -16,7 +16,7 @@ import {
   closeAccountInstruction,
   swapInstruction,
   closeMarketInstruction,
-  sweepFeesInstruction
+  sweepFeesInstruction,
 } from "./raw_instructions";
 import { OrderType, PrimedTransaction, Side } from "./types";
 import * as aaob from "@bonfida/aaob";
@@ -26,7 +26,7 @@ import { Market } from "./market";
 import {
   TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress
+  getAssociatedTokenAddress,
 } from "@solana/spl-token";
 import crypto from "crypto";
 import { getMetadataKeyFromMint } from "./metadata";
@@ -39,7 +39,7 @@ import { computeFp32Price } from "./utils";
 const MARKET_STATE_SPACE = 280;
 const ORDER_CAPACITY = 100;
 const EVENT_CAPACITY = 100;
-const U64_MAX = "18446744073709551615";
+const U64_MAX = new BN(0).notn(64);
 
 /**
  *
@@ -90,7 +90,7 @@ export const createMarket = async (
     lamports: balance,
     newAccountPubkey: marketAccount.publicKey,
     programId,
-    space: MARKET_STATE_SPACE
+    space: MARKET_STATE_SPACE,
   });
 
   // Market signer
@@ -136,7 +136,7 @@ export const createMarket = async (
     minBaseOrderSize: new BN(minBaseOrderSize),
     tickSize: tickSize,
     baseCurrencyMultiplier,
-    quoteCurrencyMultiplier
+    quoteCurrencyMultiplier,
   }).getInstruction(
     programId,
     marketAccount.publicKey,
@@ -153,7 +153,7 @@ export const createMarket = async (
   return [
     [[marketAccount], [createMarketAccount]],
     [aaobSigners, aaobInstructions],
-    [[], [createBaseVault, createQuoteVault, createMarket]]
+    [[], [createBaseVault, createQuoteVault, createMarket]],
   ];
 };
 
@@ -162,7 +162,7 @@ export const createMarket = async (
  * @param market Market object on which the order is placed
  * @param side The side of the order (Bid or Ask)
  * @param limitPrice The limit price (UI limit price not FP32)
- * @param size The size of the order (raw ammount i.e with decimals)
+ * @param size The size of the order (raw amount i.e with decimals)
  * @param type The order type
  * @param selfTradeBehaviour The self trade behavior
  * @param ownerTokenAccount The token account from which token will be debited
@@ -204,14 +204,13 @@ export const placeOrder = async (
   const instruction = new newOrderInstruction({
     side: side as number,
     limitPrice: priceFp32,
-    maxBaseQty:
-      maxBaseQty || new BN(size * market.baseCurrencyMultiplier.toNumber()),
-    maxQuoteQty: maxQuoteQty || new BN(U64_MAX),
+    maxBaseQty: maxBaseQty || new BN(size),
+    maxQuoteQty: maxQuoteQty || U64_MAX,
     orderType: type,
     selfTradeBehavior: selfTradeBehaviour,
     matchLimit: new BN(Number.MAX_SAFE_INTEGER),
     clientOrderId,
-    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1 // TODO Change
+    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1, // TODO Change
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,
@@ -256,7 +255,7 @@ export const cancelOrder = async (
   const instruction = new cancelOrderInstruction({
     orderId: clientOrderId ? clientOrderId : orderId,
     orderIndex: orderIndex ? orderIndex : new BN(0),
-    isClientId: clientOrderId ? 1 : 0
+    isClientId: clientOrderId ? 1 : 0,
   }).getInstruction(
     market.programId,
     market.address,
@@ -293,7 +292,7 @@ export const initializeAccount = async (
 
   const instruction = new initializeAccountInstruction({
     market: market.toBuffer(),
-    maxOrders: new BN(maxOrders)
+    maxOrders: new BN(maxOrders),
   }).getInstruction(
     programId,
     SystemProgram.programId,
@@ -363,7 +362,7 @@ export const consumeEvents = async (
 ) => {
   const instruction = new consumeEventsInstruction({
     maxIterations,
-    noOpErr
+    noOpErr,
   }).getInstruction(
     market.programId,
     market.address,
@@ -429,7 +428,7 @@ export const swap = async (
     quoteQty:
       side === Side.Bid ? new BN(inputQuantity) : new BN(minOutputQuantity),
     matchLimit: new BN(Number.MAX_SAFE_INTEGER), // TODO Change
-    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined)
+    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined),
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,

--- a/js/src/bindings.ts
+++ b/js/src/bindings.ts
@@ -3,7 +3,7 @@ import {
   PublicKey,
   Connection,
   SystemProgram,
-  TransactionInstruction,
+  TransactionInstruction
 } from "@solana/web3.js";
 import { DEX_ID, SRM_MINT } from "./ids";
 import {
@@ -16,7 +16,7 @@ import {
   closeAccountInstruction,
   swapInstruction,
   closeMarketInstruction,
-  sweepFeesInstruction,
+  sweepFeesInstruction
 } from "./raw_instructions";
 import { OrderType, PrimedTransaction, Side } from "./types";
 import * as aaob from "@bonfida/aaob";
@@ -26,7 +26,7 @@ import { Market } from "./market";
 import {
   TOKEN_PROGRAM_ID,
   createAssociatedTokenAccountInstruction,
-  getAssociatedTokenAddress,
+  getAssociatedTokenAddress
 } from "@solana/spl-token";
 import crypto from "crypto";
 import { getMetadataKeyFromMint } from "./metadata";
@@ -90,7 +90,7 @@ export const createMarket = async (
     lamports: balance,
     newAccountPubkey: marketAccount.publicKey,
     programId,
-    space: MARKET_STATE_SPACE,
+    space: MARKET_STATE_SPACE
   });
 
   // Market signer
@@ -116,7 +116,7 @@ export const createMarket = async (
   aaobInstructions.pop();
 
   // Base vault
-  const createBaseVault = await createAssociatedTokenAccountInstruction(
+  const createBaseVault = createAssociatedTokenAccountInstruction(
     feePayer,
     await getAssociatedTokenAddress(baseMint, marketSigner, true),
     marketSigner,
@@ -124,7 +124,7 @@ export const createMarket = async (
   );
 
   // Quote vault
-  const createQuoteVault = await createAssociatedTokenAccountInstruction(
+  const createQuoteVault = createAssociatedTokenAccountInstruction(
     feePayer,
     await getAssociatedTokenAddress(quoteMint, marketSigner, true),
     marketSigner,
@@ -136,7 +136,7 @@ export const createMarket = async (
     minBaseOrderSize: new BN(minBaseOrderSize),
     tickSize: tickSize,
     baseCurrencyMultiplier,
-    quoteCurrencyMultiplier,
+    quoteCurrencyMultiplier
   }).getInstruction(
     programId,
     marketAccount.publicKey,
@@ -153,7 +153,7 @@ export const createMarket = async (
   return [
     [[marketAccount], [createMarketAccount]],
     [aaobSigners, aaobInstructions],
-    [[], [createBaseVault, createQuoteVault, createMarket]],
+    [[], [createBaseVault, createQuoteVault, createMarket]]
   ];
 };
 
@@ -210,7 +210,7 @@ export const placeOrder = async (
     selfTradeBehavior: selfTradeBehaviour,
     matchLimit: new BN(Number.MAX_SAFE_INTEGER),
     clientOrderId,
-    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1, // TODO Change
+    hasDiscountTokenAccount: discountTokenAccount === undefined ? 0 : 1 // TODO Change
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,
@@ -255,7 +255,7 @@ export const cancelOrder = async (
   const instruction = new cancelOrderInstruction({
     orderId: clientOrderId ? clientOrderId : orderId,
     orderIndex: orderIndex ? orderIndex : new BN(0),
-    isClientId: clientOrderId ? 1 : 0,
+    isClientId: clientOrderId ? 1 : 0
   }).getInstruction(
     market.programId,
     market.address,
@@ -292,7 +292,7 @@ export const initializeAccount = async (
 
   const instruction = new initializeAccountInstruction({
     market: market.toBuffer(),
-    maxOrders: new BN(maxOrders),
+    maxOrders: new BN(maxOrders)
   }).getInstruction(
     programId,
     SystemProgram.programId,
@@ -362,7 +362,7 @@ export const consumeEvents = async (
 ) => {
   const instruction = new consumeEventsInstruction({
     maxIterations,
-    noOpErr,
+    noOpErr
   }).getInstruction(
     market.programId,
     market.address,
@@ -428,7 +428,7 @@ export const swap = async (
     quoteQty:
       side === Side.Bid ? new BN(inputQuantity) : new BN(minOutputQuantity),
     matchLimit: new BN(Number.MAX_SAFE_INTEGER), // TODO Change
-    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined),
+    hasDiscountTokenAccount: Number(discountTokenAccount !== undefined)
   }).getInstruction(
     market.programId,
     TOKEN_PROGRAM_ID,

--- a/js/src/fees.ts
+++ b/js/src/fees.ts
@@ -3,38 +3,38 @@ export const FEES = {
   6: {
     fees: { taker: 0.0003, maker: 0 },
     srm: Infinity,
-    msrm: 1,
+    msrm: 1
   },
   5: {
     fees: { taker: 0.00032, maker: 0 },
     srm: 1_000_000,
-    msrm: Infinity,
+    msrm: Infinity
   },
   4: {
     fees: { taker: 0.00034, maker: 0 },
     srm: 100_000,
-    msrm: Infinity,
+    msrm: Infinity
   },
   3: {
     fees: { taker: 0.00036, maker: 0 },
     srm: 10_000,
-    msrm: Infinity,
+    msrm: Infinity
   },
   2: {
     fees: { taker: 0.00038, maker: 0 },
     srm: 1_000,
-    msrm: Infinity,
+    msrm: Infinity
   },
   1: {
     fees: { taker: 0.00039, maker: 0 },
     srm: 100,
-    msrm: Infinity,
+    msrm: Infinity
   },
   0: {
     fees: { taker: 0.0004, maker: 0 },
     srm: 0,
-    msrm: Infinity,
-  },
+    msrm: Infinity
+  }
 };
 
 /**

--- a/js/src/ids.ts
+++ b/js/src/ids.ts
@@ -2,7 +2,7 @@ import { PublicKey } from "@solana/web3.js";
 
 // Devnet
 export const DEX_ID = new PublicKey(
-  "FCLTih6H1jMuxZSmJ13u5DnpUU7BuT8MV4By2VftggCQ"
+  "HEHEVQNZMTmjUt3CUKdddqHWa4dtXqA9QUsi7QptCCHj"
 );
 
 export const SRM_MINT = new PublicKey(

--- a/js/src/openOrders.ts
+++ b/js/src/openOrders.ts
@@ -168,11 +168,7 @@ export class OpenOrders {
       programId
     );
 
-    const userAccount = await UserAccount.retrieve(
-      connection,
-      address,
-      marketState
-    );
+    const userAccount = await UserAccount.retrieve(connection, address);
 
     return new OpenOrders(
       address,

--- a/js/src/orderbook.ts
+++ b/js/src/orderbook.ts
@@ -101,7 +101,7 @@ export class Orderbook {
         size: divideBnToNumber(
           p.size,
           new BN(10).pow(new BN(this.market.baseDecimals))
-        )
+        ),
       };
     };
     if (uiAmount) {

--- a/js/src/state.ts
+++ b/js/src/state.ts
@@ -101,16 +101,12 @@ export class MarketState {
     this.orderbook = new PublicKey(obj.orderbook);
     this.admin = new PublicKey(obj.admin);
     this.creationTimestamp = obj.creationTimestamp;
-    this.baseVolume = obj.baseVolume.mul(obj.baseCurrencyMultiplier);
-    this.quoteVolume = obj.quoteVolume.mul(obj.quoteCurrencyMultiplier);
-    this.accumulatedFees = obj.accumulatedFees.mul(obj.quoteCurrencyMultiplier);
-    this.minBaseOrderSize = obj.minBaseOrderSize.mul(
-      obj.baseCurrencyMultiplier
-    );
+    this.baseVolume = obj.baseVolume;
+    this.quoteVolume = obj.quoteVolume;
+    this.accumulatedFees = obj.accumulatedFees;
+    this.minBaseOrderSize = obj.minBaseOrderSize;
     this.royaltiesBps = obj.royaltiesBps;
-    this.accumulatedRoyalties = obj.accumulatedRoyalties.mul(
-      obj.quoteCurrencyMultiplier
-    );
+    this.accumulatedRoyalties = obj.accumulatedRoyalties;
     this.quoteCurrencyMultiplier = obj.quoteCurrencyMultiplier;
     this.baseCurrencyMultiplier = obj.baseCurrencyMultiplier;
     this.feeType = obj.feeType;
@@ -220,12 +216,7 @@ export class UserAccount {
     this.accumulatedTakerBaseVolume = obj.accumulatedTakerBaseVolume;
   }
 
-  static async retrieve(
-    connection: Connection,
-    userAccount: PublicKey,
-    marketState: MarketState
-  ) {
-    const { baseCurrencyMultiplier, quoteCurrencyMultiplier } = marketState;
+  static async retrieve(connection: Connection, userAccount: PublicKey) {
     const accountInfo = await connection.getAccountInfo(userAccount);
     if (!accountInfo?.data) {
       throw new Error("Invalid account provided");
@@ -235,15 +226,6 @@ export class UserAccount {
       UserAccount,
       accountInfo.data
     ) as UserAccount;
-    u.baseTokenFree.imul(baseCurrencyMultiplier);
-    u.baseTokenLocked.imul(baseCurrencyMultiplier);
-    u.quoteTokenFree.imul(quoteCurrencyMultiplier);
-    u.quoteTokenLocked.imul(quoteCurrencyMultiplier);
-    u.accumulatedRebates.imul(quoteCurrencyMultiplier);
-    u.accumulatedMakerQuoteVolume.imul(quoteCurrencyMultiplier);
-    u.accumulatedTakerQuoteVolume.imul(quoteCurrencyMultiplier);
-    u.accumulatedMakerBaseVolume.imul(baseCurrencyMultiplier);
-    u.accumulatedTakerBaseVolume.imul(baseCurrencyMultiplier);
     return u;
   }
 

--- a/js/tests/all.test.ts
+++ b/js/tests/all.test.ts
@@ -28,137 +28,153 @@ beforeAll(async () => {
 
 jest.setTimeout(50_000_000);
 
-// test("Create market", async () => {
-//   await createMarketTest(connection, feePayer);
-// });
+test("Create market", async () => {
+  await createMarketTest(connection, feePayer);
+});
 
-// test("Simple trade", async () => {
-//   await simpleTrade(connection, feePayer, 6, 6, 20_000, 30_000, 1, 6, 2);
-// });
+test("Simple trade", async () => {
+  await simpleTrade(connection, feePayer, 6, 6, 20_000, 30_000, 1, 6, 2);
+});
 
-// test("Simple trade (price < 1)", async () => {
-//   await simpleTrade(connection, feePayer, 6, 6, 0.01, 1, 1_000, 10_000, 0.0001);
-// });
+test("Simple trade (price < 1)", async () => {
+  await simpleTrade(connection, feePayer, 6, 6, 0.01, 1, 1_000, 10_000, 0.0001);
+});
 
-// test("Simple trade (NFT case)", async () => {
-//   await simpleTrade(
-//     connection,
-//     feePayer,
-//     0,
-//     9,
-//     1,
-//     10_000,
-//     1,
-//     20,
-//     1,
-//     undefined,
-//     new BN(Math.pow(10, 6))
-//   );
-// });
+test("Simple trade (NFT case)", async () => {
+  await simpleTrade(
+    connection,
+    feePayer,
+    0,
+    9,
+    1,
+    10_000,
+    1,
+    20,
+    1,
+    undefined,
+    new BN(Math.pow(10, 6))
+  );
+});
 
-// test("Simple trade (NFT case & price < 1)", async () => {
-//   await simpleTrade(
-//     connection,
-//     feePayer,
-//     0,
-//     9,
-//     0.01,
-//     1,
-//     1,
-//     20,
-//     0.0001,
-//     undefined,
-//     new BN(Math.pow(10, 3))
-//   );
-// });
+test("Simple trade (NFT case & price < 1)", async () => {
+  await simpleTrade(
+    connection,
+    feePayer,
+    0,
+    9,
+    0.01,
+    1,
+    1,
+    20,
+    0.0001,
+    undefined,
+    new BN(Math.pow(10, 3))
+  );
+});
 
-// test("Simple Trade (baseCurrencyMultiplier != 1)", async () => {
-//   await simpleTrade(
-//     connection,
-//     feePayer,
-//     6,
-//     6,
-//     20_000,
-//     30_000,
-//     1,
-//     6,
-//     2,
-//     new BN(10),
-//     new BN(5)
-//   );
-// });
+test("Simple trade (NFT case & price < 1 and inadapted multiplier)", async () => {
+  await simpleTrade(
+    connection,
+    feePayer,
+    0,
+    9,
+    0.01,
+    1,
+    1,
+    20,
+    0.01,
+    undefined,
+    new BN(Math.pow(10, 6))
+  );
+});
 
-// test("Orderbook (6, 6)", async () => {
-//   await orderbookTest(connection, feePayer, 6, 6, 100, 1_000, 1, 100, 2);
-// });
+test("Simple Trade (baseCurrencyMultiplier != 1)", async () => {
+  await simpleTrade(
+    connection,
+    feePayer,
+    6,
+    6,
+    20_000,
+    30_000,
+    1,
+    6,
+    2,
+    new BN(10),
+    new BN(5)
+  );
+});
 
-// test("Orderbook (6, 6) & price < 1", async () => {
-//   await orderbookTest(connection, feePayer, 6, 6, 0.01, 1, 1, 100, 0.001);
-// });
+test("Orderbook (6, 6)", async () => {
+  await orderbookTest(connection, feePayer, 6, 6, 100, 1_000, 1, 100, 2);
+});
 
-// test("Orderbook (0, 9)", async () => {
-//   await orderbookTest(
-//     connection,
-//     feePayer,
-//     0,
-//     9,
-//     10,
-//     100,
-//     1,
-//     100,
-//     2,
-//     undefined,
-//     new BN(Math.pow(10, 6))
-//   );
-// });
+test("Orderbook (6, 6) & price < 1", async () => {
+  await orderbookTest(connection, feePayer, 6, 6, 0.01, 1, 1, 100, 0.001);
+});
 
-// test("Errors", async () => {
-//   await error(connection, feePayer);
-// });
+test("Orderbook (0, 9)", async () => {
+  await orderbookTest(
+    connection,
+    feePayer,
+    0,
+    9,
+    10,
+    100,
+    1,
+    100,
+    2,
+    undefined,
+    new BN(Math.pow(10, 6))
+  );
+});
 
-// test("Swap", async () => {
-//   await swapTest(connection, feePayer, 6, 6, 100, 1_000, 10, 100, 2);
-// });
+test("Errors", async () => {
+  await error(connection, feePayer);
+});
 
-// test("Swap (price < 1)", async () => {
-//   await swapTest(connection, feePayer, 6, 6, 0, 1, 100, 1_000, 0.0001);
-// });
+test("Swap", async () => {
+  await swapTest(connection, feePayer, 6, 6, 100, 1_000, 10, 100, 2);
+});
 
-// test("Swap (NFT)", async () => {
-//   await swapTest(
-//     connection,
-//     feePayer,
-//     0,
-//     9,
-//     100,
-//     5_000,
-//     10,
-//     400,
-//     2,
-//     undefined,
-//     new BN(Math.pow(10, 6))
-//   );
-// });
+test("Swap (price < 1)", async () => {
+  await swapTest(connection, feePayer, 6, 6, 0, 1, 100, 1_000, 0.0001);
+});
 
-// test("Swap (NFT & price < 1)", async () => {
-//   await swapTest(
-//     connection,
-//     feePayer,
-//     0,
-//     9,
-//     0.01,
-//     1,
-//     100,
-//     1_000,
-//     0.001,
-//     undefined,
-//     new BN(Math.pow(10, 3))
-//   );
-// });
+test("Swap (NFT)", async () => {
+  await swapTest(
+    connection,
+    feePayer,
+    0,
+    9,
+    100,
+    5_000,
+    10,
+    400,
+    2,
+    undefined,
+    new BN(Math.pow(10, 6))
+  );
+});
 
-// test("Self trade", async () => {
-//   await selfTradeTest(connection, feePayer, 6, 6, 10, 1_000, 1, 30);
-// });
+test("Swap (NFT & price < 1)", async () => {
+  await swapTest(
+    connection,
+    feePayer,
+    0,
+    9,
+    0.01,
+    1,
+    100,
+    1_000,
+    0.001,
+    undefined,
+    new BN(Math.pow(10, 3))
+  );
+});
+
+test("Self trade", async () => {
+  await selfTradeTest(connection, feePayer, 6, 6, 10, 1_000, 1, 30);
+});
 
 test("Metadata", async () => {
   await metadataTest(connection, feePayer, 6, 6, 20_000, 30_000, 1, 6, 2);

--- a/js/tests/all.test.ts
+++ b/js/tests/all.test.ts
@@ -72,21 +72,21 @@ jest.setTimeout(50_000_000);
 //   );
 // });
 
-test("Simple Trade (baseCurrencyMultiplier != 1)", async () => {
-  await simpleTrade(
-    connection,
-    feePayer,
-    6,
-    6,
-    20_000,
-    30_000,
-    1,
-    6,
-    2,
-    new BN(10),
-    new BN(5)
-  );
-});
+// test("Simple Trade (baseCurrencyMultiplier != 1)", async () => {
+//   await simpleTrade(
+//     connection,
+//     feePayer,
+//     6,
+//     6,
+//     20_000,
+//     30_000,
+//     1,
+//     6,
+//     2,
+//     new BN(10),
+//     new BN(5)
+//   );
+// });
 
 // test("Orderbook (6, 6)", async () => {
 //   await orderbookTest(connection, feePayer, 6, 6, 100, 1_000, 1, 100, 2);

--- a/js/tests/all.test.ts
+++ b/js/tests/all.test.ts
@@ -72,6 +72,22 @@ jest.setTimeout(50_000_000);
 //   );
 // });
 
+test("Simple Trade (baseCurrencyMultiplier != 1)", async () => {
+  await simpleTrade(
+    connection,
+    feePayer,
+    6,
+    6,
+    20_000,
+    30_000,
+    1,
+    6,
+    2,
+    new BN(10),
+    new BN(5)
+  );
+});
+
 // test("Orderbook (6, 6)", async () => {
 //   await orderbookTest(connection, feePayer, 6, 6, 100, 1_000, 1, 100, 2);
 // });

--- a/js/tests/create-market.ts
+++ b/js/tests/create-market.ts
@@ -24,6 +24,7 @@ export const createMarketTest = async (
     6,
     6
   );
+  console.log("Created context");
 
   let marketObj = await MarketState.retrieve(connection, marketKey);
   const now = new Date().getTime() / 1_000;

--- a/js/tests/orderbook.ts
+++ b/js/tests/orderbook.ts
@@ -169,11 +169,7 @@ export const orderbookTest = async (
     [marketKey.toBuffer(), Bob.publicKey.toBuffer()],
     DEX_ID
   );
-  let bobUserAccount = await UserAccount.retrieve(
-    connection,
-    bobUa,
-    marketState
-  );
+  let bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   expect(bobUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(bobUserAccount.market.toBase58()).toBe(marketKey.toBase58());
   expect(bobUserAccount.owner.toBase58()).toBe(Bob.publicKey.toBase58());
@@ -233,7 +229,7 @@ export const orderbookTest = async (
    * Check user account
    */
 
-  bobUserAccount = await UserAccount.retrieve(connection, bobUa, marketState);
+  bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   expect(bobUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(bobUserAccount.market.toBase58()).toBe(marketKey.toBase58());
   expect(bobUserAccount.owner.toBase58()).toBe(Bob.publicKey.toBase58());
@@ -256,7 +252,7 @@ export const orderbookTest = async (
   ]);
   console.log(`Settled ${tx}`);
 
-  bobUserAccount = await UserAccount.retrieve(connection, bobUa, marketState);
+  bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   expect(bobUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(bobUserAccount.market.toBase58()).toBe(marketKey.toBase58());
   expect(bobUserAccount.owner.toBase58()).toBe(Bob.publicKey.toBase58());

--- a/js/tests/self-trade.ts
+++ b/js/tests/self-trade.ts
@@ -222,11 +222,7 @@ export const selfTradeTest = async (
    */
 
   // Alice
-  let aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  let aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
   const quoteTokenFree = new BN(bidSizes[0])
     .mul(executionPrice1)
     .add(new BN(bidSizes[2]).mul(executionPrice3))
@@ -265,11 +261,7 @@ export const selfTradeTest = async (
 
   // Bob
 
-  let bobUserAccount = await UserAccount.retrieve(
-    connection,
-    bobUa,
-    marketState
-  );
+  let bobUserAccount = await UserAccount.retrieve(connection, bobUa);
 
   expect(bobUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(bobUserAccount.market.toBase58()).toBe(marketKey.toBase58());
@@ -357,7 +349,7 @@ export const selfTradeTest = async (
    */
 
   // Bob
-  bobUserAccount = await UserAccount.retrieve(connection, bobUa, marketState);
+  bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   const takerVolume = new BN(2 * bidSizes[1])
     .mul(computeFp32Price(market, minPrice / 2))
     .shrn(32)

--- a/js/tests/simple-trade.ts
+++ b/js/tests/simple-trade.ts
@@ -47,7 +47,7 @@ export const simpleTrade = async (
    */
 
   const tickSize = new BN(random(0, maxTickSize) * 2 ** 32);
-  const minBaseOrderSize = new BN(1);
+  const minBaseOrderSize = baseCurrencyMultiplier || new BN(1);
   const { marketKey, base, quote, Alice, Bob } = await createContext(
     connection,
     feePayer,
@@ -172,9 +172,13 @@ export const simpleTrade = async (
 
   console.log(tx);
   const executionPrice = computeFp32Price(market, bobPrice);
-  const takerFee = computeTakerFee(new BN(bobSize).mul(executionPrice).shrn(32))
-    .mul(market.quoteCurrencyMultiplier)
-    .div(market.baseCurrencyMultiplier);
+  const takerFee = computeTakerFee(
+    new BN(bobSize)
+      .mul(executionPrice)
+      .shrn(32)
+      .mul(market.quoteCurrencyMultiplier)
+      .div(market.baseCurrencyMultiplier)
+  );
   const orderPrice = computeFp32Price(market, alicePrice);
 
   /**

--- a/js/tests/simple-trade.ts
+++ b/js/tests/simple-trade.ts
@@ -80,11 +80,7 @@ export const simpleTrade = async (
     [marketKey.toBuffer(), Alice.publicKey.toBuffer()],
     DEX_ID
   );
-  let aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  let aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
 
   expect(aliceUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(aliceUserAccount.market.toBase58()).toBe(marketKey.toBase58());
@@ -104,11 +100,7 @@ export const simpleTrade = async (
     [marketKey.toBuffer(), Bob.publicKey.toBuffer()],
     DEX_ID
   );
-  let bobUserAccount = await UserAccount.retrieve(
-    connection,
-    bobUa,
-    marketState
-  );
+  let bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   expect(bobUserAccount.tag).toBe(AccountTag.UserAccount);
   expect(bobUserAccount.market.toBase58()).toBe(marketKey.toBase58());
   expect(bobUserAccount.owner.toBase58()).toBe(Bob.publicKey.toBase58());
@@ -209,11 +201,7 @@ export const simpleTrade = async (
    * Check user accounts
    */
 
-  aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
 
   expect(aliceUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(aliceUserAccount.baseTokenLocked.toNumber()).toBe(0);
@@ -241,7 +229,7 @@ export const simpleTrade = async (
   expect(aliceUserAccount.accumulatedTakerBaseVolume.toNumber()).toBe(bobSize);
   expect(aliceUserAccount.orders.length).toBe(1);
 
-  bobUserAccount = await UserAccount.retrieve(connection, bobUa, marketState);
+  bobUserAccount = await UserAccount.retrieve(connection, bobUa);
   expect(bobUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(bobUserAccount.baseTokenLocked.toNumber()).toBe(0);
   expect(bobUserAccount.quoteTokenFree.toNumber()).toBe(0);
@@ -330,11 +318,7 @@ export const simpleTrade = async (
   ]);
   console.log(`Canceled order ${tx}`);
 
-  aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
 
   expect(aliceUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(aliceUserAccount.baseTokenLocked.toNumber()).toBe(0);
@@ -371,11 +355,7 @@ export const simpleTrade = async (
   ]);
   console.log(`Settle order ${tx}`);
 
-  aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
 
   expect(aliceUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(aliceUserAccount.baseTokenLocked.toNumber()).toBe(0);

--- a/js/tests/swap.ts
+++ b/js/tests/swap.ts
@@ -96,11 +96,7 @@ export const swapTest = async (
     [marketKey.toBuffer(), Alice.publicKey.toBuffer()],
     DEX_ID
   );
-  let aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  let aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
   expect(aliceUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(aliceUserAccount.baseTokenLocked.toNumber()).toBe(swapSize);
   expect(aliceUserAccount.quoteTokenFree.toNumber()).toBe(0);
@@ -201,11 +197,7 @@ export const swapTest = async (
   /**
    * Verify Alice user account
    */
-  aliceUserAccount = await UserAccount.retrieve(
-    connection,
-    aliceUa,
-    marketState
-  );
+  aliceUserAccount = await UserAccount.retrieve(connection, aliceUa);
   expect(aliceUserAccount.baseTokenFree.toNumber()).toBe(0);
   expect(aliceUserAccount.baseTokenLocked.toNumber()).toBe(0);
   expect(aliceUserAccount.quoteTokenFree.toNumber()).toBe(

--- a/js/tests/swap.ts
+++ b/js/tests/swap.ts
@@ -144,10 +144,12 @@ export const swapTest = async (
 
   const executionPrice = computeFp32Price(market, swapPrice);
   const takerFees = computeTakerFee(
-    new BN(swapSize).mul(executionPrice).shrn(32)
-  )
-    .mul(market.quoteCurrencyMultiplier)
-    .div(market.baseCurrencyMultiplier);
+    new BN(swapSize)
+      .mul(executionPrice)
+      .shrn(32)
+      .mul(market.quoteCurrencyMultiplier)
+      .div(market.baseCurrencyMultiplier)
+  );
 
   /**
    * Check market state

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -163,17 +163,8 @@ pub(crate) fn process(
     };
     let side = get_side_from_order_id(order_id);
 
-    order_summary.total_base_qty = order_summary
-        .total_base_qty
-        .checked_mul(market_state.base_currency_multiplier)
-        .unwrap();
-    order_summary.total_base_qty_posted = order_summary
-        .total_base_qty_posted
-        .checked_mul(market_state.base_currency_multiplier)
-        .unwrap();
-    order_summary.total_quote_qty = order_summary
-        .total_quote_qty
-        .checked_mul(market_state.quote_currency_multiplier)
+    market_state
+        .unscale_order_summary(&mut order_summary)
         .unwrap();
 
     match side {

--- a/program/src/processor/cancel_order.rs
+++ b/program/src/processor/cancel_order.rs
@@ -167,6 +167,10 @@ pub(crate) fn process(
         .total_base_qty
         .checked_mul(market_state.base_currency_multiplier)
         .unwrap();
+    order_summary.total_base_qty_posted = order_summary
+        .total_base_qty_posted
+        .checked_mul(market_state.base_currency_multiplier)
+        .unwrap();
     order_summary.total_quote_qty = order_summary
         .total_quote_qty
         .checked_mul(market_state.quote_currency_multiplier)

--- a/program/src/processor/create_market.rs
+++ b/program/src/processor/create_market.rs
@@ -176,7 +176,7 @@ pub(crate) fn process(
         base_volume: 0,
         quote_volume: 0,
         accumulated_fees: 0,
-        min_base_order_size: *min_base_order_size / *base_currency_multiplier,
+        min_base_order_size: *min_base_order_size,
         fee_type: MarketFeeType::Default as u8,
         _padding: [0; 6],
         royalties_bps: royalties_bps as u64,
@@ -186,7 +186,7 @@ pub(crate) fn process(
     };
 
     let invoke_params = agnostic_orderbook::instruction::create_market::Params {
-        min_base_order_size: *min_base_order_size,
+        min_base_order_size: *min_base_order_size / *base_currency_multiplier,
         tick_size: *tick_size,
     };
     let invoke_accounts = agnostic_orderbook::instruction::create_market::Accounts {

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -298,6 +298,10 @@ pub(crate) fn process(
         .total_base_qty
         .checked_mul(market_state.base_currency_multiplier)
         .unwrap();
+    order_summary.total_base_qty_posted = order_summary
+        .total_base_qty_posted
+        .checked_mul(market_state.base_currency_multiplier)
+        .unwrap();
     order_summary.total_quote_qty = order_summary
         .total_quote_qty
         .checked_mul(market_state.quote_currency_multiplier)

--- a/program/src/processor/new_order.rs
+++ b/program/src/processor/new_order.rs
@@ -398,9 +398,7 @@ pub(crate) fn process(
             a.key,
             accounts.user_owner.key,
             &[],
-            referral_fee
-                .checked_mul(market_state.quote_currency_multiplier)
-                .unwrap(),
+            referral_fee,
         )?;
 
         invoke_signed(

--- a/program/src/processor/settle.rs
+++ b/program/src/processor/settle.rs
@@ -123,11 +123,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
         accounts.destination_quote_account.key,
         accounts.market_signer.key,
         &[],
-        user_account
-            .header
-            .quote_token_free
-            .checked_mul(market_state.quote_currency_multiplier)
-            .unwrap(),
+        user_account.header.quote_token_free,
     )?;
 
     invoke_signed(
@@ -150,11 +146,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
         accounts.destination_base_account.key,
         accounts.market_signer.key,
         &[],
-        user_account
-            .header
-            .base_token_free
-            .checked_mul(market_state.base_currency_multiplier)
-            .unwrap(),
+        user_account.header.base_token_free,
     )?;
 
     invoke_signed(

--- a/program/src/processor/swap.rs
+++ b/program/src/processor/swap.rs
@@ -254,6 +254,10 @@ pub(crate) fn process(
         .total_base_qty
         .checked_mul(market_state.base_currency_multiplier)
         .unwrap();
+    order_summary.total_base_qty_posted = order_summary
+        .total_base_qty_posted
+        .checked_mul(market_state.base_currency_multiplier)
+        .unwrap();
     order_summary.total_quote_qty = order_summary
         .total_quote_qty
         .checked_mul(market_state.quote_currency_multiplier)

--- a/program/src/processor/sweep_fees.rs
+++ b/program/src/processor/sweep_fees.rs
@@ -151,10 +151,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
         accounts.destination_token_account.key,
         accounts.market_signer.key,
         &[],
-        market_state
-            .accumulated_fees
-            .checked_mul(market_state.quote_currency_multiplier)
-            .unwrap(),
+        market_state.accumulated_fees,
     )?;
 
     invoke_signed(

--- a/program/src/processor/sweep_fees.rs
+++ b/program/src/processor/sweep_fees.rs
@@ -89,7 +89,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
     check_accounts(program_id, &market_state, &accounts)?;
     check_metadata_account(accounts.token_metadata, &market_state.base_mint)?;
 
-    if market_state.accumulated_fees == 0 {
+    if market_state.accumulated_fees == 0 && market_state.accumulated_royalties == 0 {
         msg!("There are no fees to be extracted from the market");
         return Err(DexError::NoOp.into());
     }
@@ -137,7 +137,7 @@ pub(crate) fn process(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramR
                     ]],
                 )?;
             }
-            
+
             if share_sum != 100 {
                 msg!("Invalid metadata shares - received {}", share_sum);
                 return Err(ProgramError::InvalidAccountData);

--- a/program/src/state.rs
+++ b/program/src/state.rs
@@ -5,7 +5,7 @@ use num_derive::{FromPrimitive, ToPrimitive};
 use solana_program::{
     account_info::AccountInfo, msg, program_error::ProgramError, program_pack::Pack, pubkey::Pubkey,
 };
-use std::{cell::RefMut, mem::size_of};
+use std::{cell::RefMut, convert::TryInto, mem::size_of};
 
 use crate::{
     error::DexError,
@@ -140,8 +140,9 @@ impl DexState {
         scaled_price_fp32: u64,
     ) -> Option<u64> {
         fp32_mul(raw_base_amount, scaled_price_fp32)
-            .and_then(|n| n.checked_mul(self.quote_currency_multiplier))
-            .and_then(|n| n.checked_div(self.base_currency_multiplier))
+            .and_then(|n| (n as u128).checked_mul(self.quote_currency_multiplier as u128))
+            .and_then(|n| n.checked_div(self.base_currency_multiplier as u128))
+            .and_then(|n| n.try_into().ok())
     }
 }
 

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -13,6 +13,10 @@ use dex_v4::state::UserAccountHeader;
 use dex_v4::state::DEX_STATE_LEN;
 use dex_v4::state::USER_ACCOUNT_HEADER_LEN;
 use mpl_token_metadata::pda::find_metadata_account;
+use solana_program::account_info::AccountInfo;
+use solana_program::entrypoint::ProgramResult;
+use solana_program::msg;
+use solana_program::program_error::PrintProgramError;
 use solana_program::pubkey::Pubkey;
 use solana_program::system_instruction::create_account;
 use solana_program::system_program;
@@ -148,7 +152,7 @@ async fn test_dex() {
         },
         create_market::Params {
             signer_nonce: signer_nonce as u64,
-            min_base_order_size: 10,
+            min_base_order_size: 10_000,
             tick_size: 1,
             base_currency_multiplier: 1_000,
             quote_currency_multiplier: 1,

--- a/program/tests/functional.rs
+++ b/program/tests/functional.rs
@@ -533,7 +533,7 @@ async fn test_dex() {
         },
         swap::Params {
             side: agnostic_orderbook::state::Side::Bid as u8,
-            base_qty: 10,
+            base_qty: 10_000,
             quote_qty: 100000,
             match_limit: 10,
             has_discount_token_account: 0,


### PR DESCRIPTION
This PR makes the DEX aware of native token quantities instead of only scaled values. This allows for much better precision in fee calculations. It also simplifies parsing of DEX state in general.

Includes a fix to the `placeOrder` binding.